### PR TITLE
check_puppet now catches resource failures as well

### DIFF
--- a/check_puppet.rb
+++ b/check_puppet.rb
@@ -85,7 +85,9 @@ if File.exists?(summaryfile)
             failcount = 99
         else
             # and unless there are failures, the events hash just wont have the failure count
-            failcount = summary["events"]["failure"] || 0
+            eventsfail = summary["events"]["failure"] || 0
+            resourcesfail = summary["resources"]["failed"] || 0
+            failcount = eventsfail + resourcesfail
         end
     rescue
         failcount = 0


### PR DESCRIPTION
Using with puppet 2.7.3 with Ruby 1.8.7-p334 this works exactly as I expected it to.
