### PR TITLE
check_fokirtor.sh - replaced gdb wrapper "gcore" with gdb 

### DIFF
--- a/check_fokirtor.sh
+++ b/check_fokirtor.sh
@@ -28,7 +28,7 @@ for pid in `/bin/pidof sshd`; do
         # call gdb directly, without needing the gcore script from debian-wheezy
         #/usr/local/bin/gcore -o $t $pid >/dev/null
         gdb </dev/null --nx --batch \
-          -ex "set pagination off" -ex "set height 0 " \
+          -ex "set pagination off" -ex "set height 0 " -ex "set width 0" \
           -ex "attach $pid" -ex "gcore $t.$pid" -ex detach -ex quit
 
         for str in hbt= key= dhost= sp= sk= dip=; do


### PR DESCRIPTION
My distribution doesn't have the gcore script debian wheezy has. In order to get your script working on my machines, I just replaced the gcore call with the respective gdb call which I found in the gcore script.

It's is now working on current arch linux systems (x86, x86_64, armv6h) and still on debian, of course.
